### PR TITLE
The 1st arg of nvim_buf_xxx APIs

### DIFF
--- a/neovim-api/src/main/java/com/ensarsarajcic/neovim/java/api/buffer/BufferStreamApi.java
+++ b/neovim-api/src/main/java/com/ensarsarajcic/neovim/java/api/buffer/BufferStreamApi.java
@@ -200,7 +200,7 @@ public final class BufferStreamApi extends BaseStreamApi implements NeovimBuffer
     }
 
     private RequestMessage.Builder prepareMessage(String name) {
-        return new RequestMessage.Builder(name).addArgument(model);
+        return new RequestMessage.Builder(name).addArgument(model.getId());
     }
 
     @Override


### PR DESCRIPTION
The 1st arg should be an integer instead of the Buffer object.