### PR TITLE
Make RPCStreamer implementations release resources

### DIFF
--- a/core-rpc/src/main/java/com/ensarsarajcic/neovim/java/corerpc/client/AsyncRPCSender.java
+++ b/core-rpc/src/main/java/com/ensarsarajcic/neovim/java/corerpc/client/AsyncRPCSender.java
@@ -113,6 +113,14 @@ public final class AsyncRPCSender implements RPCSender {
         this.outgoingStream = outputStream;
     }
 
+    /**
+     * Stops the {@link ExecutorService}.
+     */
+    @Override
+    public void stop() {
+        this.executorService.shutdown();
+    }
+
     private void sendMessage(Message message) {
         if (this.outgoingStream == null) {
             throw new IllegalStateException("Can't find a connection to send message to. Did you forget to call attach?");

--- a/core-rpc/src/main/java/com/ensarsarajcic/neovim/java/corerpc/client/PackStream.java
+++ b/core-rpc/src/main/java/com/ensarsarajcic/neovim/java/corerpc/client/PackStream.java
@@ -218,6 +218,17 @@ public final class PackStream implements RPCStreamer {
         }
     }
 
+    /**
+     * Stops the underlying {@link RPCListener}
+     * It is not expected for implementation to be reusable after calling this method!
+     */
+    @Override
+    public void stop() {
+      log.info("Stopping resources");
+      this.rpcListener.stop();
+      this.rpcSender.stop();
+    }
+
     private void requestReceived(RequestMessage requestMessage) {
         log.info("Request received: {}", requestMessage);
         for (var requestCallback : requestCallbacks) {

--- a/core-rpc/src/main/java/com/ensarsarajcic/neovim/java/corerpc/client/RPCClient.java
+++ b/core-rpc/src/main/java/com/ensarsarajcic/neovim/java/corerpc/client/RPCClient.java
@@ -260,6 +260,15 @@ public final class RPCClient implements RPCStreamer {
     }
 
     /**
+     * Stops the underlying {@link RPCListener}
+     * It is not expected for implementation to be reusable after calling this method!
+     */
+    @Override
+    public void stop() {
+      rpcStreamer.stop();
+    }
+
+    /**
      * Builder for {@link RPCClient} to simplify configuration
      * Everything is set to default at the start and following may be changed:
      * * Underlying {@link RPCStreamer}

--- a/core-rpc/src/main/java/com/ensarsarajcic/neovim/java/corerpc/client/RPCSender.java
+++ b/core-rpc/src/main/java/com/ensarsarajcic/neovim/java/corerpc/client/RPCSender.java
@@ -51,4 +51,9 @@ public interface RPCSender {
      * @param outputStream {@link OutputStream} to write to
      */
     void attach(OutputStream outputStream);
+
+    /**
+     * Stops the sender
+     */
+    void stop();
 }

--- a/core-rpc/src/main/java/com/ensarsarajcic/neovim/java/corerpc/client/RPCStreamer.java
+++ b/core-rpc/src/main/java/com/ensarsarajcic/neovim/java/corerpc/client/RPCStreamer.java
@@ -102,4 +102,10 @@ public interface RPCStreamer {
      * @param notificationCallback {@link RPCListener.NotificationCallback} to remove
      */
     void removeNotificationCallback(RPCListener.NotificationCallback notificationCallback);
+
+    /**
+     * Stops the underlying {@link RPCListener}
+     * It is not expected for implementation to be reusable after calling this method!
+     */
+    void stop();
 }


### PR DESCRIPTION
By adding a `stop` method on RPCStreamer and the underlying
implementation of `PackStream` calling it, both the listener and the
sender held resources are freed/stopped.

This unblocks the process.

Verified that it closes #76.

---

I found out that my original suspicion was wrong and it wasn't the listener that was hanging the process. Instead, the offending one was the `ExecutionContext`, which was still running.

For the sake of completeness, I stopped/closed both.