### PR TITLE
Fix nvim call function to accept any arguments and not only strings

### DIFF
--- a/neovim-api/src/main/java/com/ensarsarajcic/neovim/java/api/AtomicCallBuilder.java
+++ b/neovim-api/src/main/java/com/ensarsarajcic/neovim/java/api/AtomicCallBuilder.java
@@ -108,7 +108,7 @@ public final class AtomicCallBuilder implements NeovimApi {
     }
 
     @Override
-    public CompletableFuture<Object> callFunction(String name, List<String> args) {
+    public CompletableFuture<Object> callFunction(String name, List<Object> args) {
         return null;
     }
 

--- a/neovim-api/src/main/java/com/ensarsarajcic/neovim/java/api/NeovimApi.java
+++ b/neovim-api/src/main/java/com/ensarsarajcic/neovim/java/api/NeovimApi.java
@@ -140,7 +140,7 @@ public interface NeovimApi {
     CompletableFuture<Object> eval(String expression);
 
     @NeovimApiFunction(name = CALL_FUNCTION, since = 1)
-    CompletableFuture<Object> callFunction(String name, List<String> args);
+    CompletableFuture<Object> callFunction(String name, List<Object> args);
 
     @NeovimApiFunction(name = FEEDKEYS, since = 1)
     CompletableFuture<Void> feedKeys(String keys, String mode, boolean escape);

--- a/neovim-api/src/main/java/com/ensarsarajcic/neovim/java/api/NeovimStreamApi.java
+++ b/neovim-api/src/main/java/com/ensarsarajcic/neovim/java/api/NeovimStreamApi.java
@@ -134,7 +134,7 @@ public final class NeovimStreamApi extends BaseStreamApi implements NeovimApi {
     }
 
     @Override
-    public CompletableFuture<Object> callFunction(String name, List<String> args) {
+    public CompletableFuture<Object> callFunction(String name, List<Object> args) {
         return sendWithGenericResponse(new RequestMessage.Builder(CALL_FUNCTION).addArgument(name).addArgument(args));
     }
 

--- a/neovim-api/src/test/java/com/ensarsarajcic/neovim/java/api/NeovimStreamApiTest.java
+++ b/neovim-api/src/test/java/com/ensarsarajcic/neovim/java/api/NeovimStreamApiTest.java
@@ -247,7 +247,7 @@ public class NeovimStreamApiTest extends BaseStreamApiTest {
     public void callFunctionTest() throws InterruptedException, ExecutionException {
         // Happy case
         var expectedResult = "function result";
-        var args = List.of("arg1", "arg2");
+        List<Object> args = List.of("arg1", "arg2");
         assertNormalBehavior(
                 () -> CompletableFuture.completedFuture(new ResponseMessage(1, null, expectedResult)),
                 () -> neovimStreamApi.callFunction("the function", args),
@@ -256,7 +256,7 @@ public class NeovimStreamApiTest extends BaseStreamApiTest {
         );
 
         // Error case
-        var badArgs = List.of("ont bad arg");
+        List<Object> badArgs = List.of("ont bad arg");
         assertErrorBehavior(
                 () -> neovimStreamApi.callFunction("bad function", badArgs),
                 request -> assertMethodAndArguments(request, NeovimApi.CALL_FUNCTION, "bad function", badArgs)

--- a/neovim-rx-api/src/main/java/com/ensarsarajcic/neovim/java/rxapi/NeovimRxApi.java
+++ b/neovim-rx-api/src/main/java/com/ensarsarajcic/neovim/java/rxapi/NeovimRxApi.java
@@ -77,7 +77,7 @@ public interface NeovimRxApi {
     Single<Object> eval(String expression);
 
     @NeovimApiFunction(name = NeovimApi.CALL_FUNCTION, since = 1)
-    Single<Object> callFunction(String name, List<String> args);
+    Single<Object> callFunction(String name, List<Object> args);
 
     @NeovimApiFunction(name = NeovimApi.FEEDKEYS, since = 1)
     Completable feedKeys(String keys, String mode, Boolean escape);

--- a/neovim-rx-api/src/main/java/com/ensarsarajcic/neovim/java/rxapi/NeovimRxWrapper.java
+++ b/neovim-rx-api/src/main/java/com/ensarsarajcic/neovim/java/rxapi/NeovimRxWrapper.java
@@ -114,7 +114,7 @@ public final class NeovimRxWrapper implements NeovimRxApi {
     }
 
     @Override
-    public Single<Object> callFunction(String name, List<String> args) {
+    public Single<Object> callFunction(String name, List<Object> args) {
         return Single.fromFuture(neovimApi.callFunction(name, args));
     }
 

--- a/neovim-rx-api/src/test/java/com/ensarsarajcic/neovim/java/rxapi/NeovimRxWrapperTest.java
+++ b/neovim-rx-api/src/test/java/com/ensarsarajcic/neovim/java/rxapi/NeovimRxWrapperTest.java
@@ -186,7 +186,7 @@ public class NeovimRxWrapperTest {
     @Test
     public void delegatesCallFunction() {
         var result = new Object();
-        List<String> args = Collections.emptyList();
+        List<Object> args = Collections.emptyList();
         given(neovimApi.callFunction("func", args)).willReturn(CompletableFuture.completedFuture(result));
         neovimRxWrapper.callFunction("func", args)
                 .test()


### PR DESCRIPTION
This closes #96 